### PR TITLE
use buckets-demo branch for node-moray dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "bunyan": "0.22.1",
         "jsprim": "^1.3.1",
         "lru-cache": "2.3.1",
-        "moray": "3.3.0",
+        "moray": "git+https://github.com/joyent/node-moray.git#buckets-demo",
         "once": "1.3.0",
         "restify": "2.6.3",
         "redis": "0.10.1",


### PR DESCRIPTION
When upgrading my boray environment to get bucket listing working, I was seeing the following error when starting muskie:

```
/root/manta-muskie/node_modules/libmanta/lib/buckets/moray.js:434
        self.client = moray.createBucketClient(self.morayOptions);
                            ^
TypeError: Object #<Object> has no method 'createBucketClient'
    at Array.initClient [as 0] (/root/manta-muskie/node_modules/libmanta/lib/buckets/moray.js:434:29)
    at Object.waterfall (/root/manta-muskie/node_modules/libmanta/node_modules/vasync/lib/vasync.js:608:10)
    at Moray.initAttempt (/root/manta-muskie/node_modules/libmanta/lib/buckets/moray.js:463:32)
    at new Moray (/root/manta-muskie/node_modules/libmanta/lib/buckets/moray.js:407:10)
    at new createMorayBucketClient (/root/manta-muskie/node_modules/libmanta/lib/buckets/moray.js:870:17)
    at createMorayClient (/root/manta-muskie/main.js:583:18)
    at main (/root/manta-muskie/main.js:718:5)
    at Object.<anonymous> (/root/manta-muskie/main.js:736:3)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
```

I think this is because the node-libmanta#buckets-demo branch still points to a versioned release of moray in its package.json (see [here](https://github.com/joyent/node-libmanta/blob/buckets-demo/package.json)). Manually changing that to what I've done in this PR and running an `npm install` inside the deps directory got me further in the buckets listing journey.

Testing is super light on this one unfortunately. About the only thing I can say in that regard is the note above about being able to start muskie after making this change. I'm open to further testing if it seems appropriate.